### PR TITLE
Tidy up README, gemspec etc

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2025 [name of plugin creator]
+Copyright (c) 2025 Vendo Connect Inc.
 All rights reserved.
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spree Klaviyo
 
-This is a Klaviyo extension for [Spree Commerce](https://spreecommerce.org), an open source e-commerce platform built with Ruby on Rails.
+This is an official Klaviyo email marketing extension for [Spree Commerce](https://spreecommerce.org).
 
 ## Installation
 
@@ -19,6 +19,10 @@ This is a Klaviyo extension for [Spree Commerce](https://spreecommerce.org), an 
 3. Restart your server
 
   If your server was running, restart it so that it can find the assets properly.
+
+## Configuration
+
+Go to [Klaviyo section in Spree Commerce documentation](https://spreecommerce.org/docs/integrations/klaviyo) for more information.
 
 ## Developing
 
@@ -58,4 +62,4 @@ If you'd like to contribute, please take a look at the
 [instructions](CONTRIBUTING.md) for installing dependencies and crafting a good
 pull request.
 
-Copyright (c) 2025 [name of extension creator], released under the New BSD License
+Copyright (c) 2025 [Vendo Connect Inc.](https://getvendo.com), released under the AGPL 3.0 license.

--- a/spree_klaviyo.gemspec
+++ b/spree_klaviyo.gemspec
@@ -8,21 +8,22 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_klaviyo'
   s.version     = SpreeKlaviyo::VERSION
-  s.summary     = "Spree Commerce Klaviyo Extension"
+  s.summary     = "Official Spree Commerce Klaviyo email marketing extension"
   s.required_ruby_version = '>= 3.0'
 
-  s.author    = 'You'
-  s.email     = 'you@example.com'
-  s.homepage  = 'https://github.com/your-github-handle/spree_klaviyo'
+  s.author    = 'Vendo Connect Inc.'
+  s.email     = 'hello@spreecommerce.org'
+  s.homepage  = 'https://spreecommerce.org'
   s.license = 'AGPL-3.0-or-later'
 
   s.files        = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.md", "Rakefile", "README.md"].reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree', '>= 5.0.3'
-  s.add_dependency 'spree_storefront', '>= 5.0.3'
-  s.add_dependency 'spree_admin', '>= 5.0.3'
+  spree_opts = '>= 5.1.0.beta2'
+  s.add_dependency 'spree', spree_opts
+  s.add_dependency 'spree_storefront', spree_opts
+  s.add_dependency 'spree_admin', spree_opts
   s.add_dependency 'spree_extension'
 
   s.add_development_dependency 'dotenv'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify the extension as the official Klaviyo email marketing extension for Spree Commerce and added configuration guidance.
  - Updated copyright and license information.
- **Chores**
  - Updated license file with correct copyright holder.
  - Refined gem metadata and raised minimum required versions for Spree-related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->