### PR TITLE
fix(klaviyo): Ensure marketing opt-in triggers subscription

### DIFF
--- a/app/models/concerns/spree_klaviyo/user_methods.rb
+++ b/app/models/concerns/spree_klaviyo/user_methods.rb
@@ -32,7 +32,7 @@ module SpreeKlaviyo
     end
 
     def subscribe_to_klaviyo
-      klaviyo_integration = ::Spree::Integrations::Klaviyo.active.last
+      klaviyo_integration = store_integration('klaviyo')
       return unless klaviyo_integration
 
       SpreeKlaviyo::SubscribeJob.perform_later(klaviyo_integration.id, email)

--- a/app/models/concerns/spree_klaviyo/user_methods.rb
+++ b/app/models/concerns/spree_klaviyo/user_methods.rb
@@ -32,7 +32,7 @@ module SpreeKlaviyo
     end
 
     def subscribe_to_klaviyo
-      klaviyo_integration = ::Spree::Integrations::Klaviyo.last
+      klaviyo_integration = ::Spree::Integrations::Klaviyo.active.last
       return unless klaviyo_integration
 
       SpreeKlaviyo::SubscribeJob.perform_later(klaviyo_integration.id, email)

--- a/app/models/concerns/spree_klaviyo/user_methods.rb
+++ b/app/models/concerns/spree_klaviyo/user_methods.rb
@@ -5,6 +5,8 @@ module SpreeKlaviyo
     included do
       store_accessor :private_metadata, :klaviyo_id
       store_accessor :private_metadata, :klaviyo_subscribed
+
+      after_commit :subscribe_to_klaviyo, on: :update, if: :marketing_opt_in_changed?
     end
 
     def klaviyo_subscribed?
@@ -19,6 +21,21 @@ module SpreeKlaviyo
       return if klaviyo_id.present?
 
       SpreeKlaviyo::FetchProfileJob.perform_later(klaviyo_integration.id, id)
+    end
+
+    private
+
+    def marketing_opt_in_changed?
+      return false if klaviyo_subscribed?
+
+      saved_change_to_accepted_marketing? && accepted_marketing?
+    end
+
+    def subscribe_to_klaviyo
+      klaviyo_integration = ::Spree::Integrations::Klaviyo.last
+      return unless klaviyo_integration
+
+      SpreeKlaviyo::SubscribeJob.perform_later(klaviyo_integration.id, email)
     end
   end
 end

--- a/app/models/concerns/spree_klaviyo/user_methods.rb
+++ b/app/models/concerns/spree_klaviyo/user_methods.rb
@@ -28,7 +28,7 @@ module SpreeKlaviyo
     def marketing_opt_in_changed?
       return false if klaviyo_subscribed?
 
-      saved_change_to_accepted_marketing? && accepted_marketing?
+      saved_change_to_accepts_email_marketing? && accepts_email_marketing?
     end
 
     def subscribe_to_klaviyo

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -4,23 +4,33 @@ RSpec.describe Spree.user_class, type: :model do
   include ActiveJob::TestHelper
 
   describe 'Klaviyo' do
- describe 'Klaviyo' do
-   describe '#subscribe_to_klaviyo' do
-     let(:user) { build(:user) }
-     let!(:klaviyo_integration) { create(:klaviyo_integration) }
- 
-     before do
-       ActiveJob::Base.queue_adapter = :test
-       clear_enqueued_jobs
-     end
- 
-     after { clear_enqueued_jobs }
- 
-     it 'enqueues a SubscribeJob' do
+    let(:user) { build(:user) }
+    let!(:klaviyo_integration) { create(:klaviyo_integration) }
+
+    describe '#subscribe_to_klaviyo' do
+      before do
+        ActiveJob::Base.queue_adapter = :test
+        clear_enqueued_jobs
+      end
+
+      after { clear_enqueued_jobs }
+
       it 'enqueues a SubscribeJob' do
         expect {
           user.send(:subscribe_to_klaviyo)
         }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob).with(klaviyo_integration.id, user.email)
+      end
+
+      context 'when no klaviyo integration exists' do
+        before do
+          klaviyo_integration.destroy!
+        end
+
+        it 'does not enqueue a SubscribeJob' do
+          expect {
+            user.send(:subscribe_to_klaviyo)
+          }.not_to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
+        end
       end
 
       context 'when klaviyo integration is not active' do
@@ -33,6 +43,37 @@ RSpec.describe Spree.user_class, type: :model do
             user.send(:subscribe_to_klaviyo)
           }.not_to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
         end
+      end
+    end
+
+    describe '#marketing_opt_in_changed? (private)' do
+      before do
+        allow(user).to receive(:klaviyo_subscribed?).and_return(false)
+      end
+
+      it 'returns true when flag changed and accepted_marketing is true' do
+        allow(user).to receive(:saved_change_to_accepted_marketing?).and_return(true)
+        allow(user).to receive(:accepted_marketing?).and_return(true)
+        expect(user.send(:marketing_opt_in_changed?)).to be(true)
+      end
+
+      it 'returns false when flag did not change' do
+        allow(user).to receive(:saved_change_to_accepted_marketing?).and_return(false)
+        allow(user).to receive(:accepted_marketing?).and_return(true)
+        expect(user.send(:marketing_opt_in_changed?)).to be(false)
+      end
+
+      it 'returns false when accepted_marketing is false' do
+        allow(user).to receive(:saved_change_to_accepted_marketing?).and_return(true)
+        allow(user).to receive(:accepted_marketing?).and_return(false)
+        expect(user.send(:marketing_opt_in_changed?)).to be(false)
+      end
+
+      it 'returns false when already subscribed (prevents duplicate enqueues)' do
+        allow(user).to receive(:klaviyo_subscribed?).and_return(true)
+        allow(user).to receive(:saved_change_to_accepted_marketing?).and_return(true)
+        allow(user).to receive(:accepted_marketing?).and_return(true)
+        expect(user.send(:marketing_opt_in_changed?)).to be(false)
       end
     end
   end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Spree.user_class, type: :model do
+  include ActiveJob::TestHelper
+
+  describe 'Klaviyo' do
+    describe '#subscribe_to_klaviyo' do
+      let(:user) { build(:user) }
+      let!(:klaviyo_integration) { create(:klaviyo_integration) }
+
+      it 'enqueues a SubscribeJob' do
+        expect {
+          user.send(:subscribe_to_klaviyo)
+        }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
+      end
+    end
+  end
+end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -47,10 +47,6 @@ RSpec.describe Spree.user_class, type: :model do
     end
 
     describe '#marketing_opt_in_changed? (private)' do
-      before do
-        # user.klaviyo_subscribed = false
-      end
-
       context 'when using accepts_email_marketing column (integration style)' do
         before do
           skip 'accepts_email_marketing not present in this Spree version' unless Spree.user_class.new.respond_to?(:accepts_email_marketing)

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Spree.user_class, type: :model do
           user.send(:subscribe_to_klaviyo)
         }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
       end
+
+      context 'when klaviyo integration is not active' do
+        before do
+          klaviyo_integration.update(active: false)
+        end
+
+        it 'does not enqueue a SubscribeJob' do
+          expect {
+            user.send(:subscribe_to_klaviyo)
+          }.not_to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
+        end
+      end
     end
   end
 end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -4,10 +4,19 @@ RSpec.describe Spree.user_class, type: :model do
   include ActiveJob::TestHelper
 
   describe 'Klaviyo' do
-    describe '#subscribe_to_klaviyo' do
-      let(:user) { build(:user) }
-      let!(:klaviyo_integration) { create(:klaviyo_integration) }
-
+ describe 'Klaviyo' do
+   describe '#subscribe_to_klaviyo' do
+     let(:user) { build(:user) }
+     let!(:klaviyo_integration) { create(:klaviyo_integration) }
+ 
+     before do
+       ActiveJob::Base.queue_adapter = :test
+       clear_enqueued_jobs
+     end
+ 
+     after { clear_enqueued_jobs }
+ 
+     it 'enqueues a SubscribeJob' do
       it 'enqueues a SubscribeJob' do
         expect {
           user.send(:subscribe_to_klaviyo)

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -48,10 +48,6 @@ RSpec.describe Spree.user_class, type: :model do
 
     describe '#marketing_opt_in_changed? (private)' do
       context 'when using accepts_email_marketing column (integration style)' do
-        before do
-          skip 'accepts_email_marketing not present in this Spree version' unless Spree.user_class.new.respond_to?(:accepts_email_marketing)
-        end
-
         it 'returns true when toggled from false to true on the same instance' do
           u = create(:user, accepts_email_marketing: false)
           expect(u.accepts_email_marketing).to be(false)

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Spree.user_class, type: :model do
       it 'enqueues a SubscribeJob' do
         expect {
           user.send(:subscribe_to_klaviyo)
-        }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
+        }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob).with(klaviyo_integration.id, user.email)
       end
 
       context 'when klaviyo integration is not active' do

--- a/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
+++ b/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
@@ -4,13 +4,7 @@ RSpec.describe SpreeKlaviyo::CreateOrUpdateProfile do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, user: user) }
 
   context 'when klaviyo integration is exists', :vcr do
-    let(:user) do
-      if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
-        create(:user, email: email, accepts_email_marketing: true)
-      else
-        create(:user, email: email)
-      end
-    end
+    let(:user) { create(:user, email: email, accepts_email_marketing: true) }
 
     let!(:klaviyo_integration) { create(:klaviyo_integration, preferred_klaviyo_private_api_key: 'pk_123') }
 

--- a/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
+++ b/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
@@ -99,13 +99,7 @@ RSpec.describe SpreeKlaviyo::CreateOrUpdateProfile do
   end
 
   context 'when klaviyo integration is not found' do
-    let(:user) do
-      if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
-        create(:user, accepts_email_marketing: true)
-      else
-        create(:user)
-      end
-    end
+    let(:user) { create(:user, accepts_email_marketing: true) }
     let(:klaviyo_integration) { nil }
 
     it 'returns a failure' do

--- a/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
+++ b/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
@@ -3,12 +3,14 @@ require 'spec_helper'
 RSpec.describe SpreeKlaviyo::CreateOrUpdateProfile do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, user: user) }
 
-  before do
-    allow_any_instance_of(Spree.user_class).to receive(:marketing_opt_in_changed?).and_return(false)
-  end
-
   context 'when klaviyo integration is exists', :vcr do
-    let(:user) { create(:user, email: email) }
+    let(:user) do
+      if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
+        create(:user, email: email, accepts_email_marketing: true)
+      else
+        create(:user, email: email)
+      end
+    end
 
     let!(:klaviyo_integration) { create(:klaviyo_integration, preferred_klaviyo_private_api_key: 'pk_123') }
 
@@ -103,7 +105,13 @@ RSpec.describe SpreeKlaviyo::CreateOrUpdateProfile do
   end
 
   context 'when klaviyo integration is not found' do
-    let(:user) { create(:user) }
+    let(:user) do
+      if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
+        create(:user, accepts_email_marketing: true)
+      else
+        create(:user)
+      end
+    end
     let(:klaviyo_integration) { nil }
 
     it 'returns a failure' do

--- a/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
+++ b/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 RSpec.describe SpreeKlaviyo::CreateOrUpdateProfile do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, user: user) }
 
+  before do
+    allow_any_instance_of(Spree.user_class).to receive(:marketing_opt_in_changed?).and_return(false)
+  end
+
   context 'when klaviyo integration is exists', :vcr do
     let(:user) { create(:user, email: email) }
 

--- a/spec/services/spree_klaviyo/fetch_profile_spec.rb
+++ b/spec/services/spree_klaviyo/fetch_profile_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe SpreeKlaviyo::FetchProfile do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, user: user) }
 
-  let(:user) { create(:user) }
-
-  before do
-    allow(user).to receive(:marketing_opt_in_changed?).and_return(false)
+  let(:user) do
+    user_attributes = {}
+    user_attributes[:accepts_email_marketing] = true if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
+    create(:user, user_attributes)
   end
 
   describe '#call' do

--- a/spec/services/spree_klaviyo/fetch_profile_spec.rb
+++ b/spec/services/spree_klaviyo/fetch_profile_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 describe SpreeKlaviyo::FetchProfile do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, user: user) }
 
-  let(:user) do
-    create(:user, accepts_email_marketing: true)
-  end
+  let(:user) { create(:user, accepts_email_marketing: true) }
 
   describe '#call' do
     context 'when klaviyo integration is exists' do

--- a/spec/services/spree_klaviyo/fetch_profile_spec.rb
+++ b/spec/services/spree_klaviyo/fetch_profile_spec.rb
@@ -5,6 +5,10 @@ describe SpreeKlaviyo::FetchProfile do
 
   let(:user) { create(:user) }
 
+  before do
+    allow(user).to receive(:marketing_opt_in_changed?).and_return(false)
+  end
+
   describe '#call' do
     context 'when klaviyo integration is exists' do
       let!(:klaviyo_integration) { create(:klaviyo_integration) }

--- a/spec/services/spree_klaviyo/fetch_profile_spec.rb
+++ b/spec/services/spree_klaviyo/fetch_profile_spec.rb
@@ -4,9 +4,7 @@ describe SpreeKlaviyo::FetchProfile do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, user: user) }
 
   let(:user) do
-    user_attributes = {}
-    user_attributes[:accepts_email_marketing] = true if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
-    create(:user, user_attributes)
+    create(:user, accepts_email_marketing: true)
   end
 
   describe '#call' do

--- a/spec/services/spree_klaviyo/unsubscribe_spec.rb
+++ b/spec/services/spree_klaviyo/unsubscribe_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 describe SpreeKlaviyo::Unsubscribe do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, email: email, user: user) }
 
-  let(:user) { create(:user) }
-  let(:email) { user.email }
-
-  before do
-    allow_any_instance_of(Spree.user_class).to receive(:marketing_opt_in_changed?).and_return(false)
+  let(:email) { FFaker::Internet.email }
+  let(:user) do
+    if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
+      create(:user, email: email, accepts_email_marketing: true)
+    else
+      create(:user, email: email)
+    end
   end
 
   describe '#call' do
@@ -47,7 +49,6 @@ describe SpreeKlaviyo::Unsubscribe do
 
         context 'when emails belongs to guest user' do
           let(:user) { nil }
-          let(:email) { FFaker::Internet.email }
 
           it 'returns success' do
             expect(subject.success?).to be true

--- a/spec/services/spree_klaviyo/unsubscribe_spec.rb
+++ b/spec/services/spree_klaviyo/unsubscribe_spec.rb
@@ -18,7 +18,7 @@ describe SpreeKlaviyo::Unsubscribe do
         before do
           allow_any_instance_of(Spree::Integrations::Klaviyo)
             .to receive(:unsubscribe_user).with(email)
-                                          .and_return(Spree::ServiceModule::Result.new(true, user))
+            .and_return(Spree::ServiceModule::Result.new(true, user))
         end
 
         context 'when email belongs to registered user' do
@@ -59,7 +59,7 @@ describe SpreeKlaviyo::Unsubscribe do
         it 'returns failure' do
           allow_any_instance_of(Spree::Integrations::Klaviyo)
             .to receive(:unsubscribe_user).with(email)
-                                          .and_return(Spree::ServiceModule::Result.new(false, user))
+            .and_return(Spree::ServiceModule::Result.new(false, user))
 
           expect(subject.success?).to be false
         end

--- a/spec/services/spree_klaviyo/unsubscribe_spec.rb
+++ b/spec/services/spree_klaviyo/unsubscribe_spec.rb
@@ -4,10 +4,7 @@ describe SpreeKlaviyo::Unsubscribe do
   subject { described_class.call(klaviyo_integration: klaviyo_integration, email: email, user: user) }
 
   let(:email) { FFaker::Internet.email }
-  let(:user) do
-    create(:user, email: email, accepts_email_marketing: true)
-    end
-  end
+  let(:user) { create(:user, email: email, accepts_email_marketing: true) }
 
   describe '#call' do
     context 'when klaviyo integration exists' do

--- a/spec/services/spree_klaviyo/unsubscribe_spec.rb
+++ b/spec/services/spree_klaviyo/unsubscribe_spec.rb
@@ -6,6 +6,10 @@ describe SpreeKlaviyo::Unsubscribe do
   let(:user) { create(:user) }
   let(:email) { user.email }
 
+  before do
+    allow_any_instance_of(Spree.user_class).to receive(:marketing_opt_in_changed?).and_return(false)
+  end
+
   describe '#call' do
     context 'when klaviyo integration exists' do
       let!(:klaviyo_integration) { create(:klaviyo_integration) }
@@ -14,7 +18,7 @@ describe SpreeKlaviyo::Unsubscribe do
         before do
           allow_any_instance_of(Spree::Integrations::Klaviyo)
             .to receive(:unsubscribe_user).with(email)
-            .and_return(Spree::ServiceModule::Result.new(true, user))
+                                          .and_return(Spree::ServiceModule::Result.new(true, user))
         end
 
         context 'when email belongs to registered user' do
@@ -55,7 +59,7 @@ describe SpreeKlaviyo::Unsubscribe do
         it 'returns failure' do
           allow_any_instance_of(Spree::Integrations::Klaviyo)
             .to receive(:unsubscribe_user).with(email)
-            .and_return(Spree::ServiceModule::Result.new(false, user))
+                                          .and_return(Spree::ServiceModule::Result.new(false, user))
 
           expect(subject.success?).to be false
         end

--- a/spec/services/spree_klaviyo/unsubscribe_spec.rb
+++ b/spec/services/spree_klaviyo/unsubscribe_spec.rb
@@ -5,10 +5,7 @@ describe SpreeKlaviyo::Unsubscribe do
 
   let(:email) { FFaker::Internet.email }
   let(:user) do
-    if Spree.user_class.new.respond_to?(:accepts_email_marketing=)
-      create(:user, email: email, accepts_email_marketing: true)
-    else
-      create(:user, email: email)
+    create(:user, email: email, accepts_email_marketing: true)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 ENV['RAILS_ENV'] = 'test'
 require 'dotenv/load'
 
-require File.expand_path('dummy/config/environment.rb', __dir__)
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 require 'spree_dev_tools/rspec/spec_helper'
 require 'spree_klaviyo/factories'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 ENV['RAILS_ENV'] = 'test'
 require 'dotenv/load'
 
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require 'spree_dev_tools/rspec/spec_helper'
 require 'spree_klaviyo/factories'
@@ -10,5 +10,7 @@ require 'spree_klaviyo/factories'
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].sort.each { |f| require f }
+
+ActiveRecord::Migration.maintain_test_schema!
 
 Spree::LegacyUser.include SpreeKlaviyo::UserMethods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,4 @@ require 'spree_klaviyo/factories'
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].sort.each { |f| require f }
 
-ActiveRecord::Migration.maintain_test_schema!
-
 Spree::LegacyUser.include SpreeKlaviyo::UserMethods


### PR DESCRIPTION
### Summary
This pull request fixes a bug where users were not being subscribed to the Klaviyo marketing list after opting in.
### The Problem
The subscription job was not being triggered when a user opted into marketing emails via checkout, the newsletter form, or their account page.
### The Solution
The logic in the **marketing_opt_in_changed?** method has been corrected. It now ensures the subscription job is dispatched only when a user's accepted_marketing status is newly changed to true, fixing the issue where the process was previously blocked.
### How to Test
**Action:** Opt-in to marketing via the newsletter form, checkout, or the "My Account" page.
**Verification:** Confirm the user is added to the Klaviyo list VnA882. If double opt-in is enabled, check for the confirmation email first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically subscribes users to Klaviyo when they newly opt into marketing during profile updates; only triggers on real opt-in changes and avoids duplicate subscriptions.

* **Tests**
  * Added specs validating subscription job enqueueing for active integrations and non-enqueueing when missing/inactive.
  * Updated several service specs and test setups to explicitly opt users into email marketing for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->