### PR TITLE
CHG klaviyo default queue

### DIFF
--- a/lib/spree_klaviyo.rb
+++ b/lib/spree_klaviyo.rb
@@ -5,7 +5,9 @@ require 'spree_klaviyo/version'
 require 'spree_klaviyo/configuration'
 
 module SpreeKlaviyo
+  mattr_accessor :queue
+
   def self.queue
-    'spree_klaviyo'
+    @@queue ||= Spree.queues.default
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose which background job queue the integration uses, allowing alignment with your store’s existing queue configuration.
* **Chores**
  * Updated default behavior to use the application’s default queue instead of a fixed queue name, improving compatibility and reducing manual setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->