### PR TITLE
feat: Make job queue configurable

### DIFF
--- a/lib/spree_klaviyo.rb
+++ b/lib/spree_klaviyo.rb
@@ -6,6 +6,6 @@ require 'spree_klaviyo/configuration'
 
 module SpreeKlaviyo
   def self.queue
-    'spree_klaviyo'
+    SpreeKlaviyo::Config.queue
   end
 end

--- a/lib/spree_klaviyo/configuration.rb
+++ b/lib/spree_klaviyo/configuration.rb
@@ -4,5 +4,6 @@ module SpreeKlaviyo
     preference :klaviyo_api_revision, :string, default: '2025-04-15'
     preference :klaviyo_api_open_timeout, :integer, default: 10
     preference :klaviyo_api_read_timeout, :integer, default: 10
+    preference :queue, :string, default: 'spree_klaviyo'
   end
 end


### PR DESCRIPTION
**Why:**

Currently, the background job queue for `spree_klaviyo` is hardcoded to `'spree_klaviyo'`. This requires developers to explicitly add this queue to their `sidekiq.yml` and prevents them from using custom queue configurations, which is a common practice in Spree applications.

This change introduces a configuration option to set the queue name, aligning the gem with standard Spree conventions and providing more flexibility.

**What:**

*   Added a `queue` preference to `SpreeKlaviyo::Configuration` with a default value of `'spree_klaviyo'` to maintain backward compatibility.
*   Updated the `SpreeKlaviyo.queue` method to use the new configuration setting.

**How to use:**

Developers can now configure the queue name in an initializer (e.g., `config/initializers/spree_klaviyo.rb`):

```ruby
# config/initializers/spree_klaviyo.rb

SpreeKlaviyo::Config.tap do |config|
  # Example: Set the queue to Spree's default queue
  config.queue = Spree.queues.default

  # Example: Set a custom queue name
  # config.queue = :my_custom_klaviyo_queue
end
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable queue name for Klaviyo-related background jobs, allowing alignment with your existing queuing setup.
  * Default queue remains unchanged for backward compatibility; no action required unless you want to customize.
  * Configuration option is available in application settings, enabling easier operations and environment-specific tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->