### PR TITLE
Spree 5.x compatibility: remove deprecated preference DSL, update configuration, and provide factory

### DIFF
--- a/app/clients/spree_klaviyo/klaviyo/client.rb
+++ b/app/clients/spree_klaviyo/klaviyo/client.rb
@@ -11,7 +11,7 @@ module SpreeKlaviyo
       def get_request(api_endpoint)
         request = Net::HTTP::Get.new(url(api_endpoint))
         request["accept"] = "application/json"
-        request["revision"] = SpreeKlaviyo::Config[:klaviyo_api_revision]
+        request["revision"] = SpreeKlaviyo::Configuration.klaviyo_api_revision
         request["Authorization"] = "Klaviyo-API-Key #{private_api_key}"
 
         response = http.request(request)
@@ -26,7 +26,7 @@ module SpreeKlaviyo
       def post_request(api_endpoint, body)
         request = Net::HTTP::Post.new(url(api_endpoint))
         request["accept"] = "application/json"
-        request["revision"] = SpreeKlaviyo::Config[:klaviyo_api_revision]
+        request["revision"] = SpreeKlaviyo::Configuration.klaviyo_api_revision
         request["content-type"] = "application/json"
         request["Authorization"] = "Klaviyo-API-Key #{private_api_key}"
         request.body = body.to_json
@@ -43,7 +43,7 @@ module SpreeKlaviyo
       def patch_request(api_endpoint, body)
         request = Net::HTTP::Patch.new(url(api_endpoint))
         request["accept"] = "application/json"
-        request["revision"] = SpreeKlaviyo::Config[:klaviyo_api_revision]
+        request["revision"] = SpreeKlaviyo::Configuration.klaviyo_api_revision
         request["content-type"] = "application/json"
         request["Authorization"] = "Klaviyo-API-Key #{private_api_key}"
         request.body = body.to_json
@@ -62,14 +62,14 @@ module SpreeKlaviyo
       attr_reader :public_api_key, :private_api_key
 
       def url(endpoint = "")
-        @url ||= URI.join(SpreeKlaviyo::Config[:klaviyo_api_url], endpoint)
+        @url ||= URI.join(SpreeKlaviyo::Configuration.klaviyo_api_url, endpoint)
       end
 
       def http
         @http ||= Net::HTTP.new(url.host, url.port).tap do |net_http_instance|
           net_http_instance.use_ssl = true
-          net_http_instance.open_timeout = SpreeKlaviyo::Config[:klaviyo_api_open_timeout]
-          net_http_instance.read_timeout = SpreeKlaviyo::Config[:klaviyo_api_read_timeout]
+          net_http_instance.open_timeout = SpreeKlaviyo::Configuration.klaviyo_api_open_timeout
+          net_http_instance.read_timeout = SpreeKlaviyo::Configuration.klaviyo_api_read_timeout
         end
       end
     end

--- a/lib/spree_klaviyo/configuration.rb
+++ b/lib/spree_klaviyo/configuration.rb
@@ -1,8 +1,21 @@
 module SpreeKlaviyo
-  class Configuration < Spree::Preferences::Configuration
-    preference :klaviyo_api_url, :string, default: 'https://a.klaviyo.com/api/'
-    preference :klaviyo_api_revision, :string, default: '2025-04-15'
-    preference :klaviyo_api_open_timeout, :integer, default: 10
-    preference :klaviyo_api_read_timeout, :integer, default: 10
+  class Configuration
+    class << self
+      def klaviyo_api_url
+        ENV.fetch('KLAVIYO_API_URL', 'https://a.klaviyo.com/api/')
+      end
+
+      def klaviyo_api_revision
+        ENV.fetch('KLAVIYO_API_REVISION', '2025-04-15')
+      end
+
+      def klaviyo_api_open_timeout
+        ENV.fetch('KLAVIYO_API_OPEN_TIMEOUT', 10).to_i
+      end
+
+      def klaviyo_api_read_timeout
+        ENV.fetch('KLAVIYO_API_READ_TIMEOUT', 10).to_i
+      end
+    end
   end
 end

--- a/lib/spree_klaviyo/testing_support/factories/klaviyo_integration.rb
+++ b/lib/spree_klaviyo/testing_support/factories/klaviyo_integration.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :klaviyo_integration, class: Spree::Integrations::Klaviyo do
     active { true }
-    preferred_klaviyo_public_api_key { ENV.fetch("KLAVIYO_PUBLIC_API_KEY", "1234") }
-    preferred_klaviyo_private_api_key { ENV.fetch("KLAVIYO_PRIVATE_API_KEY", "1234567899") }
-    preferred_default_newsletter_list_id { ENV.fetch("KLAVIYO_DEFAULT_NEWSLETTER_LIST_ID", "1234") }
+    klaviyo_public_api_key { ENV.fetch("KLAVIYO_PUBLIC_API_KEY", "1234") }
+    klaviyo_private_api_key { ENV.fetch("KLAVIYO_PRIVATE_API_KEY", "1234567899") }
+    default_newsletter_list_id { ENV.fetch("KLAVIYO_DEFAULT_NEWSLETTER_LIST_ID", "1234") }
     store { Spree::Store.default }
   end
 end

--- a/spec/models/spree/integrations/klaviyo_spec.rb
+++ b/spec/models/spree/integrations/klaviyo_spec.rb
@@ -19,17 +19,17 @@ describe Spree::Integrations::Klaviyo, type: :model do
 
   describe 'validations' do
     it 'validates presence of klaviyo_public_api_key' do
-      klaviyo_integration.preferred_klaviyo_public_api_key = nil
+      klaviyo_integration.klaviyo_public_api_key = nil
       expect(klaviyo_integration).not_to be_valid
     end
 
     it 'validates presence of klaviyo_private_api_key' do
-      klaviyo_integration.preferred_klaviyo_private_api_key = nil
+      klaviyo_integration.klaviyo_private_api_key = nil
       expect(klaviyo_integration).not_to be_valid
     end
 
     it 'validates presence of default_newsletter_list_id' do
-      klaviyo_integration.preferred_default_newsletter_list_id = nil
+      klaviyo_integration.default_newsletter_list_id = nil
       expect(klaviyo_integration).not_to be_valid
     end
   end
@@ -40,9 +40,9 @@ describe Spree::Integrations::Klaviyo, type: :model do
     let(:klaviyo_integration) do
       create(
         :klaviyo_integration,
-        preferred_klaviyo_public_api_key: 'RZUvUQ',
-        preferred_klaviyo_private_api_key: 'pk_8d2bcc4570678967f4d3756fed304430eb',
-        preferred_default_newsletter_list_id: 'XLUG56'
+        klaviyo_public_api_key: 'RZUvUQ',
+        klaviyo_private_api_key: 'pk_8d2bcc4570678967f4d3756fed304430eb',
+        default_newsletter_list_id: 'XLUG56'
       )
     end
     let(:email) { 'example@email.com' }
@@ -79,9 +79,9 @@ describe Spree::Integrations::Klaviyo, type: :model do
     let(:klaviyo_integration) do
       create(
         :klaviyo_integration,
-        preferred_klaviyo_public_api_key: 'RZUvUQ',
-        preferred_klaviyo_private_api_key: 'pk_8d2bcc4570678967f4d3756fed304430eb',
-        preferred_default_newsletter_list_id: 'XLUG56'
+        klaviyo_public_api_key: 'RZUvUQ',
+        klaviyo_private_api_key: 'pk_8d2bcc4570678967f4d3756fed304430eb',
+        default_newsletter_list_id: 'XLUG56'
       )
     end
     let(:email) { 'example@email.com' }
@@ -151,9 +151,9 @@ describe Spree::Integrations::Klaviyo, type: :model do
     let!(:klaviyo_integration) do
       create(
         :klaviyo_integration,
-        preferred_klaviyo_public_api_key: 'RZUvUQ',
-        preferred_klaviyo_private_api_key: 'pk_8d2bcc4570678967f4d3756fed304430eb',
-        preferred_default_newsletter_list_id: 'XLUG56'
+        klaviyo_public_api_key: 'RZUvUQ',
+        klaviyo_private_api_key: 'pk_8d2bcc4570678967f4d3756fed304430eb',
+        default_newsletter_list_id: 'XLUG56'
       )
     end
 
@@ -164,7 +164,7 @@ describe Spree::Integrations::Klaviyo, type: :model do
     end
 
     it 'returns failure' do
-      klaviyo_integration.preferred_klaviyo_private_api_key = 'invalid_key'
+      klaviyo_integration.klaviyo_private_api_key = 'invalid_key'
       klaviyo_integration.save
       VCR.use_cassette('klaviyo/create_event/order_completed/failure') do
         expect(subject.success?).to be false
@@ -194,9 +194,9 @@ describe Spree::Integrations::Klaviyo, type: :model do
     let(:klaviyo_integration) do
       create(
         :klaviyo_integration,
-        preferred_klaviyo_public_api_key: 'RZUvUQ',
-        preferred_klaviyo_private_api_key: klaviyo_private_api_key,
-        preferred_default_newsletter_list_id: default_newsletter_list_id
+        klaviyo_public_api_key: 'RZUvUQ',
+        klaviyo_private_api_key: klaviyo_private_api_key,
+        default_newsletter_list_id: default_newsletter_list_id
       )
     end
 

--- a/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
+++ b/spec/services/spree_klaviyo/create_or_update_profile_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SpreeKlaviyo::CreateOrUpdateProfile do
   context 'when klaviyo integration is exists', :vcr do
     let(:user) { create(:user, email: email, accepts_email_marketing: true) }
 
-    let!(:klaviyo_integration) { create(:klaviyo_integration, preferred_klaviyo_private_api_key: 'pk_123') }
+    let!(:klaviyo_integration) { create(:klaviyo_integration, klaviyo_private_api_key: 'pk_123') }
 
     context 'when user has a profile in Klaviyo' do
       let(:email) { 'existing.user@getvendo.com' }


### PR DESCRIPTION
### Summary:

- Replace deprecated preference-based API in Spree::Integrations::Klaviyo to work with Spree 5.x.
- Update SpreeKlaviyo::Configuration to use ENV-backed getters to avoid reliance on preference DSL.
- Ensure a working klaviyo_integration factory is available under lib/spree_klaviyo/testing_support/factories/ for downstream apps/specs.

### Motivation:

- Spree 5.x deprecated/removed several preference APIs, breaking spree_klaviyo at boot (e.g., NoMethodError: undefined method preference).
- This PR restores compatibility with Spree 5.x apps without requiring app-level monkey patches.

### Changes:

- app/models/spree/integrations/klaviyo.rb: remove deprecated preference DSL usage; adjust consumers to read attributes expected by Spree 5.x.
- lib/spree_klaviyo/configuration.rb: replace Spree::Preferences::Configuration + preference with ENV-backed configuration methods.
- lib/spree_klaviyo/testing_support/factories/klaviyo_integration.rb: include a factory for integration specs.

### Breaking changes:

None for typical configurations that set keys via environment variables or app-level code. If an app relied on the old preferred_... accessors directly, they’ll need to switch to the new attributes or ENV.

### Testing:

- Updated/verified gem specs.
- Verified in a Spree 5.x Rails app: boot succeeds, controller specs pass, and factory is loadable via require 'spree_klaviyo/testing_support/factories/klaviyo_integration'.

### Release notes:

- Add Spree 5.x compatibility by removing deprecated preference DSL usage and updating configuration to ENV-based accessors.
- Provide a factory for integration specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configuration values for Klaviyo (API URL, revision, timeouts) can now be set via environment variables.
- Refactor
  - Simplified Klaviyo integration settings: renamed credentials and list ID fields for consistency.
  - Internal client now reads configuration from the new settings source; behavior remains unchanged.
- Tests
  - Updated factories and specs to align with the new configuration and field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->