### PR TITLE
Bump spree_klaviyo to 1.0.4

### DIFF
--- a/lib/spree_klaviyo/version.rb
+++ b/lib/spree_klaviyo/version.rb
@@ -1,5 +1,5 @@
 module SpreeKlaviyo
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 
   def gem_version
     Gem::Version.new(VERSION)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped package version to 1.0.4 for a patch release.
  - No user-facing functionality changes; existing features continue to work as before.
  - Includes routine release housekeeping to ensure accurate versioning and distribution.
  - Safe to upgrade; no configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->