### PR TITLE
Update Gemfile for new spree gem location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails-controller-testing'
 spree_opts = if ENV['SPREE_PATH']
                 { 'path': ENV['SPREE_PATH'] }
              else
-                { 'github': 'spree/spree', 'branch': 'main' }
+                { 'github': 'spree/spree', 'branch': 'main', 'glob': 'backend/engines/**/*.gemspec' }
              end
 gem 'spree', spree_opts
 gem 'spree_admin', spree_opts


### PR DESCRIPTION
## Summary
- Updates the Bundler github source for spree/spree to include `glob: 'backend/engines/**/*.gemspec'`
- The spree gems have been moved from the root of the spree/spree repository to `backend/engines/`

## Test plan
- [x] `bundle update` succeeds
- [x] `bundle exec rake test_app` succeeds
- [x] `bundle exec rspec` passes (100 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined package dependency configuration to enable more selective and efficient discovery during build initialization, optimizing resource usage and improving build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->