### PR TITLE
Add e2e specs

### DIFF
--- a/spec/subscribers/spree_klaviyo/newsletter_subscriber_spec.rb
+++ b/spec/subscribers/spree_klaviyo/newsletter_subscriber_spec.rb
@@ -11,10 +11,13 @@ RSpec.describe SpreeKlaviyo::NewsletterSubscriber do
   describe '#newsletter_subscriber.created event' do
     let(:email) { 'customer@example.com' }
 
-    it 'enqueues SubscribeJob when a newsletter subscriber is created via checkout' do
+    it 'enqueues SubscribeJob with correct arguments' do
       expect {
         Spree::Newsletter::Subscribe.new(email: email).call
-      }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
+      }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob).with { |integration_id, subscriber_id|
+        expect(integration_id).to eq(klaviyo_integration.id)
+        expect(Spree::NewsletterSubscriber.find(subscriber_id).email).to eq(email)
+      }
     end
 
     it 'does not enqueue SubscribeJob when subscriber already exists' do
@@ -39,10 +42,10 @@ RSpec.describe SpreeKlaviyo::NewsletterSubscriber do
   describe '#newsletter_subscriber.deleted event' do
     let!(:existing_subscriber) { create(:newsletter_subscriber) }
 
-    it 'enqueues UnsubscribeJob when a newsletter subscriber is destroyed' do
+    it 'enqueues UnsubscribeJob with correct arguments' do
       expect {
         existing_subscriber.destroy!
-      }.to have_enqueued_job(SpreeKlaviyo::UnsubscribeJob)
+      }.to have_enqueued_job(SpreeKlaviyo::UnsubscribeJob).with(klaviyo_integration.id, existing_subscriber.email)
     end
 
     context 'without klaviyo integration' do

--- a/spec/subscribers/spree_klaviyo/newsletter_subscriber_spec.rb
+++ b/spec/subscribers/spree_klaviyo/newsletter_subscriber_spec.rb
@@ -6,46 +6,55 @@ RSpec.describe SpreeKlaviyo::NewsletterSubscriber do
   let(:newsletter_subscriber) { create(:newsletter_subscriber) }
   let!(:klaviyo_integration) { create(:klaviyo_integration, store: store) }
 
+  around do |example|
+    perform_enqueued_jobs(only: Spree::Events::SubscriberJob) { example.run }
+  end
+
   describe '#newsletter_subscriber.created event' do
-    let(:event) do
-      Spree::Event.new(
-        name: 'newsletter_subscriber.created',
-        payload: newsletter_subscriber.event_payload,
-        store_id: store.id
-      )
+    let(:email) { 'customer@example.com' }
+
+    it 'enqueues SubscribeJob when a newsletter subscriber is created via checkout' do
+      expect {
+        Spree::Newsletter::Subscribe.new(email: email).call
+      }.to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
     end
 
-    it 'enqueues SubscribeJob' do
-      expect(SpreeKlaviyo::SubscribeJob).to receive(:perform_later).with(klaviyo_integration.id, newsletter_subscriber.id)
-      invoke_subscriber
+    it 'does not enqueue SubscribeJob when subscriber already exists' do
+      create(:newsletter_subscriber, email: email)
+
+      expect {
+        Spree::Newsletter::Subscribe.new(email: email).call
+      }.not_to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
     end
 
     context 'without klaviyo integration' do
       before { klaviyo_integration.destroy! }
 
       it 'does not enqueue SubscribeJob' do
-        expect(SpreeKlaviyo::SubscribeJob).not_to receive(:perform_later)
-        invoke_subscriber
+        expect {
+          Spree::Newsletter::Subscribe.new(email: email).call
+        }.not_to have_enqueued_job(SpreeKlaviyo::SubscribeJob)
       end
     end
   end
 
   describe '#newsletter_subscriber.deleted event' do
-    let(:event) do
-      Spree::Event.new(
-        name: 'newsletter_subscriber.deleted',
-        payload: newsletter_subscriber.event_payload,
-        store_id: store.id
-      )
+    let!(:existing_subscriber) { create(:newsletter_subscriber) }
+
+    it 'enqueues UnsubscribeJob when a newsletter subscriber is destroyed' do
+      expect {
+        existing_subscriber.destroy!
+      }.to have_enqueued_job(SpreeKlaviyo::UnsubscribeJob)
     end
 
-    before do
-      newsletter_subscriber.delete
-    end
+    context 'without klaviyo integration' do
+      before { klaviyo_integration.destroy! }
 
-    it 'enqueues UnsubscribeJob' do
-      expect(SpreeKlaviyo::UnsubscribeJob).to receive(:perform_later).with(klaviyo_integration.id, newsletter_subscriber.email)
-      invoke_subscriber
+      it 'does not enqueue UnsubscribeJob' do
+        expect {
+          existing_subscriber.destroy!
+        }.not_to have_enqueued_job(SpreeKlaviyo::UnsubscribeJob)
+      end
     end
   end
 end

--- a/spec/subscribers/spree_klaviyo/newsletter_subscriber_spec.rb
+++ b/spec/subscribers/spree_klaviyo/newsletter_subscriber_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SpreeKlaviyo::NewsletterSubscriber do
-  subject(:invoke_subscriber) { described_class.new.call(event) }
   let(:store) { Spree::Store.default }
-  let(:newsletter_subscriber) { create(:newsletter_subscriber) }
   let!(:klaviyo_integration) { create(:klaviyo_integration, store: store) }
 
   around do |example|

--- a/spec/subscribers/spree_klaviyo/newsletter_subscription_end_to_end_spec.rb
+++ b/spec/subscribers/spree_klaviyo/newsletter_subscription_end_to_end_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe 'Klaviyo end-to-end newsletter subscription' do
+  let(:store) { Spree::Store.default }
+  let!(:klaviyo_integration) { create(:klaviyo_integration, store: store) }
+  let(:email) { 'user@example.com' }
+  let(:subscriber) { Spree::NewsletterSubscriber.find_by(email: email) }
+
+  context 'when Klaviyo API succeeds' do
+    it 'creates and marks subscriber as subscribed in Klaviyo' do
+      VCR.use_cassette('services/spree_klaviyo/subscribe/success') do
+        perform_enqueued_jobs(only: [Spree::Events::SubscriberJob, SpreeKlaviyo::SubscribeJob]) do
+          Spree::Newsletter::Subscribe.new(email: email).call
+        end
+      end
+
+      expect(subscriber).to be_present
+      expect(
+        ActiveModel::Type::Boolean.new.cast(subscriber.get_metafield('klaviyo.subscribed')&.value)
+      ).to eq(true)
+    end
+  end
+
+  context 'when Klaviyo API fails' do
+    let!(:klaviyo_integration) { create(:klaviyo_integration, store: store, preferred_default_newsletter_list_id: 'invalid-list-id') }
+
+    it 'creates newsletter subscriber but does not mark as subscribed' do
+      VCR.use_cassette('services/spree_klaviyo/subscribe/failure') do
+        perform_enqueued_jobs(only: [Spree::Events::SubscriberJob, SpreeKlaviyo::SubscribeJob]) do
+          Spree::Newsletter::Subscribe.new(email: email).call
+        end
+      end
+
+      expect(subscriber).to be_present
+      expect(subscriber.get_metafield('klaviyo.subscribed')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Small addition to https://github.com/spree/spree_klaviyo/pull/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored newsletter subscriber tests to use actual API flows instead of direct invocations.
  * Added end-to-end test coverage for Klaviyo newsletter subscription behavior, including success and failure scenarios.
  * Improved test reliability by controlling job execution scope and verifying integration behavior with recorded HTTP interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->