### PR TITLE
Update Spree dependency version to 5.3.0

### DIFF
--- a/spree_klaviyo.gemspec
+++ b/spree_klaviyo.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_opts = '>= 5.1.0.beta2'
+  spree_opts = '>= 5.3.0'
   s.add_dependency 'spree', spree_opts
   s.add_dependency 'spree_admin', spree_opts
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum version requirements for Spree and Spree Admin dependencies to 5.3.0 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->