### PR TITLE
V-3437 updates to deprecation warnings

### DIFF
--- a/app/presenters/spree_klaviyo/order_presenter.rb
+++ b/app/presenters/spree_klaviyo/order_presenter.rb
@@ -91,7 +91,7 @@ module SpreeKlaviyo
 
     def try_variants(variant)
       {
-        variant_dict: ::Spree::Variants::OptionsPresenter.new(variant).to_hash
+        variant_dict: variant.options_text
       }
     end
   end

--- a/app/presenters/spree_klaviyo/product_presenter.rb
+++ b/app/presenters/spree_klaviyo/product_presenter.rb
@@ -16,11 +16,11 @@ module SpreeKlaviyo
       {
         name: @product.name,
         price: @product.amount_in(current_currency)&.to_f,
-        brand: @product&.brand_name,
+        brand: @product&.brand_taxon&.name,
         category: @product.main_taxon&.pretty_name,
         currency: current_currency,
         url: respond_to?(:spree_storefront_resource_url) ? spree_storefront_resource_url(@product, store: @current_store) : nil,
-        image_url: @product.default_image.present? ? spree_image_url(@product.default_image, width: 1200, height: 1200, format: :png) : '',
+        image_url: @product.primary_media.present? ? spree_image_url(@product.primary_media, width: 1200, height: 1200, format: :png) : '',
         sku: @product.sku
       }
     end

--- a/app/presenters/spree_klaviyo/product_presenter.rb
+++ b/app/presenters/spree_klaviyo/product_presenter.rb
@@ -20,7 +20,7 @@ module SpreeKlaviyo
         category: @product.main_taxon&.pretty_name,
         currency: current_currency,
         url: respond_to?(:spree_storefront_resource_url) ? spree_storefront_resource_url(@product, store: @current_store) : nil,
-        image_url: @product.primary_media.present? ? spree_image_url(@product.primary_media, width: 1200, height: 1200, format: :png) : '',
+        image_url: @product.primary_media&.attached? ? spree_image_url(@product.primary_media, width: 1200, height: 1200, format: :png) : '',
         sku: @product.sku
       }
     end

--- a/app/presenters/spree_klaviyo/shipment_presenter.rb
+++ b/app/presenters/spree_klaviyo/shipment_presenter.rb
@@ -37,7 +37,7 @@ module SpreeKlaviyo
         shipped_items_quantity = shipped_item.line_item.quantity
         {
           url: respond_to?(:spree_storefront_resource_url) ? spree_storefront_resource_url(shipped_item.variant.product, store: @current_store) : nil,
-          image_url: shipped_item.variant.primary_media.present? ? spree_image_url(shipped_item.variant.primary_media, width: 1200, height: 1200, format: :png) : '',
+          image_url: shipped_item.variant.primary_media&.attached? ? spree_image_url(shipped_item.variant.primary_media, width: 1200, height: 1200, format: :png) : '',
           name: shipped_item.variant.name,
           variant: shipped_item.variant.options_text,
           sku: shipped_item.variant.sku,

--- a/app/presenters/spree_klaviyo/shipment_presenter.rb
+++ b/app/presenters/spree_klaviyo/shipment_presenter.rb
@@ -37,7 +37,7 @@ module SpreeKlaviyo
         shipped_items_quantity = shipped_item.line_item.quantity
         {
           url: respond_to?(:spree_storefront_resource_url) ? spree_storefront_resource_url(shipped_item.variant.product, store: @current_store) : nil,
-          image_url: shipped_item.variant.default_image.present? ? spree_image_url(shipped_item.variant.default_image, width: 1200, height: 1200, format: :png) : '',
+          image_url: shipped_item.variant.primary_media.present? ? spree_image_url(shipped_item.variant.primary_media, width: 1200, height: 1200, format: :png) : '',
           name: shipped_item.variant.name,
           variant: shipped_item.variant.options_text,
           sku: shipped_item.variant.sku,
@@ -45,7 +45,7 @@ module SpreeKlaviyo
           total_quantity: shipped_items_quantity,
           price: shipped_item.line_item.price.to_f,
           total_price: shipped_item.line_item.amount.to_f,
-          brand: shipped_item.variant.product.brand_name
+          brand: shipped_item.variant.product.brand_taxon&.name
         }.merge(try_variants(shipped_item.variant))
       end
     end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Klaviyo payload shape/content for variants, brands, and images, which could affect downstream analytics/flows expecting the previous fields. Limited in scope to presenter serialization with no auth or data persistence changes.
> 
> **Overview**
> Klaviyo presenter payloads now **emit different variant/brand/image fields**.
> 
> `OrderPresenter#try_variants` sends `variant_dict` as `variant.options_text` instead of the options presenter hash. `ProductPresenter` and `ShipmentPresenter` now source `brand` from `brand_taxon.name` and prefer `primary_media` for `image_url` instead of `default_image`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81b24ab705abfb34b7dd583d9ccf7e80d65dc2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Updated Klaviyo product image selection to prioritize primary media over default images, ensuring consistency across data synchronization
* Modified how brand information is sourced in product and shipment data—now uses product brand taxonomy instead of brand name attribute
* Changed how variant options are formatted in order payloads sent to Klaviyo, using simplified option text representation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree_klaviyo/pull/27)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->